### PR TITLE
Add support for "starts/ends with" operators in indexer

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package    BL_RuleOperators
+ * @author     Falco Nogatz <fnogatz@gmail.com>
+ * @copyright  Copyright (c) 2019 Falco Nogatz
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace BL\RuleOperators\Helper;
+
+use \Magento\Framework\App\Helper\AbstractHelper;
+
+class Data extends AbstractHelper
+{
+    const INPUT_TYPE_STRING = 'string';
+
+    const OPERATOR_START_WITH = 'blro-^_';
+    const OPERATOR_NOT_START_WITH = '!blro-^_';
+    const OPERATOR_END_WITH = 'blro-_$';
+    const OPERATOR_NOT_END_WITH = '!blro-_$';
+    const OPERATOR_MATCH_REGEX = 'blro-regex';
+    const OPERATOR_NOT_MATCH_REGEX = '!blro-regex';
+
+    const OPERATORS = [
+        self::OPERATOR_START_WITH,
+        self::OPERATOR_NOT_START_WITH,
+        self::OPERATOR_END_WITH,
+        self::OPERATOR_NOT_END_WITH,
+        self::OPERATOR_MATCH_REGEX,
+        self::OPERATOR_NOT_MATCH_REGEX,
+    ];
+}

--- a/Plugin/Rule/ConditionPlugin.php
+++ b/Plugin/Rule/ConditionPlugin.php
@@ -9,28 +9,10 @@
 namespace BL\RuleOperators\Plugin\Rule;
 
 use Magento\Rule\Model\Condition\AbstractCondition;
-
+use BL\RuleOperators\Helper\Data;
 
 class ConditionPlugin
 {
-    const INPUT_TYPE_STRING = 'string';
-
-    const OPERATOR_START_WITH = 'blro-^_';
-    const OPERATOR_NOT_START_WITH = '!blro-^_';
-    const OPERATOR_END_WITH = 'blro-_$';
-    const OPERATOR_NOT_END_WITH = '!blro-_$';
-    const OPERATOR_MATCH_REGEX = 'blro-regex';
-    const OPERATOR_NOT_MATCH_REGEX = '!blro-regex';
-
-    const OPERATORS = [
-        self::OPERATOR_START_WITH,
-        self::OPERATOR_NOT_START_WITH,
-        self::OPERATOR_END_WITH,
-        self::OPERATOR_NOT_END_WITH,
-        self::OPERATOR_MATCH_REGEX,
-        self::OPERATOR_NOT_MATCH_REGEX,
-    ];
-
     /**
      * @param AbstractCondition $subject
      * @param array $operators
@@ -38,16 +20,16 @@ class ConditionPlugin
      */
     public function afterGetDefaultOperatorInputByType(AbstractCondition $subject, array $operators)
     {
-        if (isset($operators[self::INPUT_TYPE_STRING]) && is_array($operators[self::INPUT_TYPE_STRING])) {
-            $operators[self::INPUT_TYPE_STRING] = array_merge(
-                $operators[self::INPUT_TYPE_STRING],
+        if (isset($operators[Data::INPUT_TYPE_STRING]) && is_array($operators[Data::INPUT_TYPE_STRING])) {
+            $operators[Data::INPUT_TYPE_STRING] = array_merge(
+                $operators[Data::INPUT_TYPE_STRING],
                 [
-                    self::OPERATOR_START_WITH,
-                    self::OPERATOR_NOT_START_WITH,
-                    self::OPERATOR_END_WITH,
-                    self::OPERATOR_NOT_END_WITH,
-                    self::OPERATOR_MATCH_REGEX,
-                    self::OPERATOR_NOT_MATCH_REGEX,
+                    Data::OPERATOR_START_WITH,
+                    Data::OPERATOR_NOT_START_WITH,
+                    Data::OPERATOR_END_WITH,
+                    Data::OPERATOR_NOT_END_WITH,
+                    Data::OPERATOR_MATCH_REGEX,
+                    Data::OPERATOR_NOT_MATCH_REGEX,
                 ]
             );
         }
@@ -62,12 +44,12 @@ class ConditionPlugin
      */
     public function afterGetDefaultOperatorOptions(AbstractCondition $subject, array $options)
     {
-        $options[self::OPERATOR_START_WITH] = __('starts with');
-        $options[self::OPERATOR_NOT_START_WITH] = __('does not start with');
-        $options[self::OPERATOR_END_WITH] = __('ends with');
-        $options[self::OPERATOR_NOT_END_WITH] = __('does not end with');
-        $options[self::OPERATOR_MATCH_REGEX] = __('matches regular expression');
-        $options[self::OPERATOR_NOT_MATCH_REGEX] = __('does not match regular expression');
+        $options[Data::OPERATOR_START_WITH] = __('starts with');
+        $options[Data::OPERATOR_NOT_START_WITH] = __('does not start with');
+        $options[Data::OPERATOR_END_WITH] = __('ends with');
+        $options[Data::OPERATOR_NOT_END_WITH] = __('does not end with');
+        $options[Data::OPERATOR_MATCH_REGEX] = __('matches regular expression');
+        $options[Data::OPERATOR_NOT_MATCH_REGEX] = __('does not match regular expression');
         return $options;
     }
 
@@ -81,7 +63,7 @@ class ConditionPlugin
     {
         $operator = $subject->getOperatorForValidate();
 
-        if (in_array($operator, self::OPERATORS, true)) {
+        if (in_array($operator, Data::OPERATORS, true)) {
             if (is_object($validatedValue)) {
                 return false;
             }
@@ -90,16 +72,16 @@ class ConditionPlugin
             $result = null;
 
             switch ($operator) {
-                case self::OPERATOR_START_WITH:
-                case self::OPERATOR_NOT_START_WITH:
+                case Data::OPERATOR_START_WITH:
+                case Data::OPERATOR_NOT_START_WITH:
                     $result = (bool) preg_match('/^' . preg_quote($value, '/') . '/iu', $validatedValue);
                     break;
-                case self::OPERATOR_END_WITH:
-                case self::OPERATOR_NOT_END_WITH:
+                case Data::OPERATOR_END_WITH:
+                case Data::OPERATOR_NOT_END_WITH:
                     $result = (bool) preg_match('/' . preg_quote($value, '/') . '$/iu', $validatedValue);
                     break;
-                case self::OPERATOR_MATCH_REGEX:
-                case self::OPERATOR_NOT_MATCH_REGEX:
+                case Data::OPERATOR_MATCH_REGEX:
+                case Data::OPERATOR_NOT_MATCH_REGEX:
                     $result = (bool) @preg_match($this->prepareMatchableRegex($value), $validatedValue);
                     break;
             }

--- a/Plugin/Rule/CriteriaMapperPlugin.php
+++ b/Plugin/Rule/CriteriaMapperPlugin.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package    BL_RuleOperators
+ * @author     Falco Nogatz <fnogatz@gmail.com>
+ * @copyright  Copyright (c) 2019 Falco Nogatz
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace BL\RuleOperators\Plugin\Rule;
+
+use Magento\CatalogRule\Model\Rule\Condition\Combine as CombinedCondition;
+use Magento\CatalogRule\Model\Rule\Condition\Product as SimpleCondition;
+use Magento\CatalogRule\Model\Rule\Condition\ConditionsToSearchCriteriaMapper;
+use BL\RuleOperators\Helper\Data;
+
+class CriteriaMapperPlugin
+{
+    public function beforeMapConditionsToSearchCriteria(ConditionsToSearchCriteriaMapper $subject, CombinedCondition $conditions)
+    {
+        foreach ($conditions->getConditions() as $condition) {
+            if ($condition->getType() === SimpleCondition::class) {
+                switch ($condition->getOperator()) {
+                    case Data::OPERATOR_START_WITH:
+                        $condition->setOperator('{}');
+                        $condition->setValue($condition->getValue().'%');
+                        break;
+                    case Data::OPERATOR_NOT_START_WITH:
+                        $condition->setOperator('!{}');
+                        $condition->setValue($condition->getValue().'%');
+                        break;
+                    case Data::OPERATOR_END_WITH:
+                        $condition->setOperator('{}');
+                        $condition->setValue('%'.$condition->getValue());
+                        break;
+                    case Data::OPERATOR_NOT_END_WITH:
+                        $condition->setOperator('!{}');
+                        $condition->setValue('%'.$condition->getValue());
+                        break;
+                    case Data::OPERATOR_MATCH_REGEX:
+                    case Data::OPERATOR_NOT_MATCH_REGEX:
+                        throw new InputException(
+                            __('RegExp are not yet allowed in Indexer')
+                        );
+                        break;
+                }
+            }
+        }
+
+        return [$conditions];
+    }
+}

--- a/Plugin/SearchCriteria/AttributeConditionPlugin.php
+++ b/Plugin/SearchCriteria/AttributeConditionPlugin.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package    BL_RuleOperators
+ * @author     Falco Nogatz <fnogatz@gmail.com>
+ * @copyright  Copyright (c) 2019 Falco Nogatz
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace BL\RuleOperators\Plugin\SearchCriteria;
+
+use Magento\Framework\Api\Filter;
+use Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\ConditionProcessor\ConditionBuilder\NativeAttributeCondition;
+
+class AttributeConditionPlugin
+{
+    public function afterBuild(NativeAttributeCondition $subject, string $filter): string {
+        $filter = preg_replace("/LIKE '%([^']+)%%'/", "LIKE '$1%'", $filter);
+        $filter = preg_replace("/LIKE '%%([^']+)%'/", "LIKE '%$1'", $filter);
+
+        return $filter;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,4 +12,10 @@
     <type name="Magento\Rule\Model\Condition\AbstractCondition">
         <plugin name="blro_rule_condition_plugin" type="BL\RuleOperators\Plugin\Rule\ConditionPlugin" sortOrder="0"/>
     </type>
+    <type name="Magento\CatalogRule\Model\Rule\Condition\ConditionsToSearchCriteriaMapper">
+        <plugin name="blro_rule_condition_plugin" type="BL\RuleOperators\Plugin\Rule\CriteriaMapperPlugin" sortOrder="0"/>
+    </type>
+    <type name="Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\ConditionProcessor\ConditionBuilder\NativeAttributeCondition">
+        <plugin name="blro_rule_condition_plugin" type="BL\RuleOperators\Plugin\SearchCriteria\AttributeConditionPlugin" sortOrder="0"/>
+    </type>
 </config>


### PR DESCRIPTION
I could not apply catalog and cart price rules containing the custom rule operators, since the indexer throws:

```sh
> cat var/log/exception.log
[2019-11-05 01:51:30] main.CRITICAL: Undefined rule operator "blro-^_" passed in. Valid operators are: ==,!=,>=,<=,>,<,{},!{},(),!(),<=> {"exception":"[object] (Magento\\Framework\\Exception\\InputException(code: 0): Undefined rule operator \"blro-^_\" passed in. Valid operators are: ==,!=,>=,<=,>,<,{},!{},(),!(),<=> at vendor/magento/module-catalog-rule/Model/Rule/Condition/ConditionsToSearchCriteriaMapper.php:285)"} []
```

This PR rewrites the custom operators `OPERATOR_START_WITH`, `OPERATOR_NOT_START_WITH`, `OPERATOR_END_WITH`, and `OPERATOR_NOT_END_WITH` to Magento's built-in string operator `{}` (*LIKE*) and `!{}` (*NOT LIKE*). 

Magento SQL builder natively has no support for *LIKE* queries with a wildcard symbol on just one side. `NativeAttributeCondition::build` calls `NativeAttributeCondition::mapConditionValue` which always adds a leading and closing percentage symbol `%` for *(NOT) LIKE*. Therefore we have to use a small hack to first add a second `%` and later remove the additional pair of `%` in `AttributeConditionPlugin::afterBuild`.

What's still missing is to add support for indexing the custom rule operators `OPERATOR_MATCH_REGEX` and `OPERATOR_NOT_MATCH_REGEX`. Though *REGEXP* is also defined in `Magento\Framework\DB\Adapter\Pdo\Mysql::prepareSqlCondition`, there is no equivalent built-in string operator, like for `{}` as before. So adding support for *REGEXP* will require additional changes...