### PR TITLE
Remove % placeholders that have been added in CriteriaMapperPlugin

### DIFF
--- a/Plugin/Rule/ConditionPlugin.php
+++ b/Plugin/Rule/ConditionPlugin.php
@@ -89,6 +89,9 @@ class ConditionPlugin
 
             $isNegatedOperator = '!' === substr($operator, 0, 1);
             return (null !== $result) ? ($isNegatedOperator ? !$result : $result) : false;
+        } else if (in_array($operator, ['{}', '!{}'])) {
+            // replace `%` placeholders that have been added in CriteriaMapperPlugin
+            $subject->setValueParsed(preg_replace('(^%|%$)', '', $subject->getValueParsed()));
         }
 
         return $proceed($validatedValue);


### PR DESCRIPTION
With the latest Magento release (at least from v2.3.4 on), the indexer first creates a list of matched products (SQL created via our `CriteriaMapperPlugin`), and then again validates all of them programmatically via `$cond->validate()`. But since we added the `%` symbol in the first step (to add support for *start with* and *end with*), we have to remove the additional `%` again.

This does not affect the usage of the `blro-...` operator when used without the indexer (e.g., in widgets), as they are not replaced at all in these use cases. On the other hand it does not have side effects on the normal `{}` operators, as long as their values don't start or end with a `%`.